### PR TITLE
Add new yaml loader

### DIFF
--- a/manage/cli.py
+++ b/manage/cli.py
@@ -40,8 +40,9 @@ def load_manage_dict(filename=None):
             )
             MANAGE_DICT['shell']['auto_import']['display'] = False
         if manage_filename:
+            loader = yaml.FullLoader if hasattr(yaml, 'FullLoader') else yaml.Loader
             with open(manage_filename) as manage_file:
-                MANAGE_DICT.update(yaml.load(manage_file))
+                MANAGE_DICT.update(yaml.load(manage_file, Loader=loader))
     return MANAGE_DICT
 
 


### PR DESCRIPTION
Avoid `calling yaml.load() without Loader=... is deprecated`